### PR TITLE
Do not restrict content types to Apendix C

### DIFF
--- a/3MF Core Specification.md
+++ b/3MF Core Specification.md
@@ -12,7 +12,7 @@
 
 
 
-| **Version** | 1.2.2 |
+| **Version** | 1.2.3 |
 | --- | --- |
 | **Status** | Published |
 
@@ -153,7 +153,7 @@ A payload that has a 3D Model root part is known as a _3D payload_. There can be
 
 A specific relationship type is defined to identify the root of a 3D payload within a 3MF Document: the _3MF Document StartPart relationship_. The _primary 3D payload root_ is the 3D Model part that is referenced by the 3MF Document StartPart relationship to find the primary 3D payload in a package. The 3MF Document StartPart relationship MUST point to the 3D Model part that identifies the root of the 3D payload.
 
-The payload includes the full set of parts required for processing the 3D Model part. All content to be used to manufacture an object described in the 3D payload MUST be contained in the 3MF Document. The parts that can be found in a 3MF Document are listed in Table 2-1. Relationships and content types for these parts are defined in Appendix C, "Standard Namespaces and Content Types." Each part MUST use only the appropriate content type specified in Appendix C.
+The payload includes the full set of parts required for processing the 3D Model part. All content to be used to manufacture an object described in the 3D payload MUST be contained in the 3MF Document. The parts that can be found in a 3MF Document are listed in Table 2-1. Relationships and content types for these parts are defined in Appendix C, "Standard Namespaces and Content Types." Each part MUST use an appropriate content type specified in Appendix C or in an extension specification to 3MF (see [2.3.1. Support for Versioning and Extensibility]).
 
 Parts included to the 3D payload are explicitly linked to the 3D payload root by relationship. 3MF Documents MUST NOT reference resources external to the 3MF Document package unless specified otherwise in an extension. For more information on relationships, see the Open Packaging Conventions specification.
 


### PR DESCRIPTION
A first read of the core-specification can lead to the interpretation that non-standard content types (outside of Appendix C.1.) are not allowed by the 3MF Core Specification.

This change clarifies that content types are not restricted to the list in Appendix C.1.