### PR TITLE
Improve PDF generation

### DIFF
--- a/markdownToPDF/mdToPDF.sh
+++ b/markdownToPDF/mdToPDF.sh
@@ -24,7 +24,7 @@
 #!/bin/bash
 
 mkdir ~/.grip
-echo "PASSWORD = ${GITHUB_API_KEY}" > ~/.grip/settings.py
+echo "PASSWORD = '${GITHUB_API_KEY}'" > ~/.grip/settings.py
 cat ~/.grip/settings.py
 
 FILE="$1"

--- a/markdownToPDF/mdToPDF.sh
+++ b/markdownToPDF/mdToPDF.sh
@@ -23,6 +23,10 @@
 
 #!/bin/bash
 
+mkdir ~/.grip
+echo "PASSWORD = ${GITHUB_API_KEY}" > ~/.grip/settings.py
+cat ~/.grip/settings.py
+
 FILE="$1"
 TMPFILE="temp.html"
 

--- a/markdownToPDF/mdToPDF.sh
+++ b/markdownToPDF/mdToPDF.sh
@@ -25,7 +25,6 @@
 
 mkdir ~/.grip
 echo "PASSWORD = '${GITHUB_API_KEY}'" > ~/.grip/settings.py
-cat ~/.grip/settings.py
 
 FILE="$1"
 TMPFILE="temp.html"

--- a/markdownToPDF/mdToPDF.sh
+++ b/markdownToPDF/mdToPDF.sh
@@ -34,6 +34,7 @@ sed -i 's|<a href="images/3mf_logo_50px.png"|<a|g' "$TMPFILE"
 sed -i 's|<a href="#|<a href="@|g' "$TMPFILE"
 sed -i 's|href="#|name="|g' "$TMPFILE"
 sed -i 's|<a href="@|<a href="#|g' "$TMPFILE"
+sed -i 's|<pre|<pre style="white-space: pre-wrap;"|g' "$TMPFILE"
 
 MARGIN=14
 


### PR DESCRIPTION
- wrap long lines of code
- add GITHUB_API_KEY for grip: this way, conversions will not fail due to github's rate limiting